### PR TITLE
Fix Phaser.GameObjects.Components.Pipeline#postPipelines doc

### DIFF
--- a/src/gameobjects/components/Pipeline.js
+++ b/src/gameobjects/components/Pipeline.js
@@ -60,7 +60,7 @@ var Pipeline = {
      * If you modify this array directly, be sure to set the
      * `hasPostPipeline` property accordingly.
      *
-     * @name Phaser.GameObjects.Components.Pipeline#postPipeline
+     * @name Phaser.GameObjects.Components.Pipeline#postPipelines
      * @type {Phaser.Renderer.WebGL.Pipelines.PostFXPipeline[]}
      * @webglOnly
      * @since 3.50.0


### PR DESCRIPTION
* Updates the Documentation

Describe the changes below:
The `s` was missing in the doc for `postPipelines`, leading to wrong Typescript typing and misleading documentation.
